### PR TITLE
feat/header-search-bar-12356

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "stevia",
   "name": "minimumtheme",
-  "version": "6.0.61",
+  "version": "6.0.62",
   "builders": {
     "styles": "2.x",
     "store": "0.x",

--- a/react/AppBanner/index.jsx
+++ b/react/AppBanner/index.jsx
@@ -15,7 +15,7 @@ const AppBanner = props => {
           />
         </div>
         <div className={styles.wrapperTextContent}>
-          <h4>Biostévi Pharma</h4>
+          <span>Biostévi Pharma</span>
           <p>Baixe o app Biostévi Pharma</p>
         </div>
       </div>

--- a/react/AppBanner/style.module.css
+++ b/react/AppBanner/style.module.css
@@ -6,9 +6,6 @@
   height: 50px;
   padding-left: 8px;
   padding-right: 8px;
-  position: sticky;
-  top: 0;
-  z-index: 1000;
 }
 
 .wrapperLogoText {

--- a/react/AppBanner/style.module.css
+++ b/react/AppBanner/style.module.css
@@ -27,7 +27,10 @@
   margin-left: 15px;
 }
 
-.wrapperTextContent h4,
+.wrapperTextContent span {
+  font-weight: 600;
+}
+.wrapperTextContent span,
 .wrapperTextContent p {
   margin-top: 0px;
   margin-bottom: 0px;

--- a/react/SearchButton.jsx
+++ b/react/SearchButton.jsx
@@ -1,0 +1,3 @@
+import SearchButton from './SearchButton/index'
+
+export default SearchButton

--- a/react/SearchButton/index.global.css
+++ b/react/SearchButton/index.global.css
@@ -1,3 +1,33 @@
+/* Wrapper do botão de busca com controle de max-width */
+.search-button-wrapper {
+    max-width: 0;
+    opacity: 0;
+    overflow: hidden;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Quando estiver sticky E a search-bar externa não estiver visível, permite que o botão apareça */
+.search-button-wrapper--sticky {
+    max-width: 45px;
+    pointer-events: auto;
+    opacity: 1;
+}
+
+/* Quando estiver sticky E ativo (search visível), mantém os 45px */
+.search-button-wrapper--sticky.search-button-wrapper--active {
+    max-width: 45px;
+    opacity: 1;
+}
+
+/* Para garantir que o botão só apareça quando sticky E quando a search externa não estiver visível */
+.search-button-wrapper:not(.search-button-wrapper--sticky) {
+    max-width: 0;
+    pointer-events: none;
+}
+
 /* Botão de busca */
 .search-button {
     background: none;
@@ -12,16 +42,23 @@
     border-radius: 4px;
     min-width: 36px;
     min-height: 36px;
+    flex-shrink: 0;
 }
 
-/* Estilos para o search-bar original quando ativo no sticky */
+/* Botão desabilitado quando a search externa está visível */
+.search-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+/* Estilos para o search-bar quando ativo no sticky (posicionamento e visuais) */
 .vtex-sticky-layout-0-x-wrapper--stuck .vtex-store-components-3-x-searchBarContainer.search-active {
     display: block !important;
     visibility: visible !important;
-    height: auto !important;
-    max-height: none !important;
-    overflow: visible !important;
     opacity: 1 !important;
+    max-height: 60px !important;
+    overflow: visible !important;
     position: absolute;
     top: 100%;
     left: 0;
@@ -30,34 +67,23 @@
     background: #d2d3d3;
     border-top: 1px solid #e0e0e0;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-    animation: slideDown 0.2s ease-out;
-    padding: 15px;
+    padding: 15px !important;
     transform: translateY(0) !important;
     pointer-events: auto !important;
+    transition: all 0.3s ease;
 }
 
-/* Garante que quando não estiver sticky, o search-bar volte ao comportamento normal */
-.vtex-store-components-3-x-searchBarContainer:not(.search-active) {
-    display: block;
-    visibility: visible;
-    height: auto;
-    overflow: visible;
-    opacity: 1;
-    position: static !important;
-    background: transparent !important;
-    border: none !important;
-    box-shadow: none !important;
-    animation: none !important;
-}
-
+/* Animação suave para a abertura da search-bar */
 @keyframes slideDown {
     from {
         opacity: 0;
+        max-height: 0;
         transform: translateY(-10px);
     }
 
     to {
         opacity: 1;
+        max-height: 60px;
         transform: translateY(0);
     }
 }
@@ -82,18 +108,10 @@
 }
 
 /* Transições suaves para elementos que serão escondidos/mostrados */
-.vtex-store-components-3-x-searchBarContainer {
-    transition: opacity 0.3s ease, max-height 0.3s ease, padding 0.3s ease;
+.vtex-sticky-layout-0-x-wrapper .vtex-store-components-3-x-searchBarContainer {
+    transition: all 0.3s ease;
     overflow: hidden;
     display: block;
-}
-
-.vtex-flex-layout-0-x-flexRowContent--container-app-content,
-.vtex-flex-layout-0-x-flexRow--AppBanner,
-[class*="wrapperBannerApp"],
-.vtex-flex-layout-0-x-flexRowContent--AppBanner {
-    transition: opacity 0.3s ease, max-height 0.3s ease, transform 0.3s ease;
-    overflow: hidden;
 }
 
 /* Transição suave para o próprio sticky layout */
@@ -106,42 +124,12 @@
     transition: all 0.3s ease;
 }
 
-/* Esconde o search bar original quando sticky no mobile */
+/* Responsivo - ajustes para mobile */
 @media (max-width: 1024px) {
-    .vtex-sticky-layout-0-x-wrapper--stuck .vtex-store-components-3-x-searchBarContainer:not(.search-active) {
-        opacity: 0;
-        max-height: 0;
-        padding-top: 0;
-        padding-bottom: 0;
-        transform: translateY(-10px);
-        pointer-events: none;
-    }
-
-    /* Esconde o AppBanner quando o header estiver sticky - várias tentativas de seletor */
-    .vtex-sticky-layout-0-x-wrapper--stuck .vtex-flex-layout-0-x-flexRowContent--container-app-content {
-        opacity: 0;
-        max-height: 0;
-        transform: translateY(-10px);
-    }
-
-    .vtex-sticky-layout-0-x-wrapper--stuck .vtex-flex-layout-0-x-flexRow--AppBanner {
-        opacity: 0;
-        max-height: 0;
-        transform: translateY(-10px);
-    }
-
-    /* Tenta pelo componente direto */
-    .vtex-sticky-layout-0-x-wrapper--stuck [class*="wrapperBannerApp"] {
-        opacity: 0;
-        max-height: 0;
-        transform: translateY(-10px);
-    }
-
-    /* Tenta pelo flex-layout que contém o AppBanner */
-    .vtex-sticky-layout-0-x-wrapper--stuck .vtex-flex-layout-0-x-flexRowContent--AppBanner {
-        opacity: 0;
-        max-height: 0;
-        transform: translateY(-10px);
+    /* Estado ativo no mobile */
+    .vtex-sticky-layout-0-x-wrapper--stuck .vtex-store-components-3-x-searchBarContainer.search-active {
+        max-height: 60px !important;
+        padding: 12px 15px !important;
     }
 }
 
@@ -154,13 +142,15 @@
     }
 
     .vtex-sticky-layout-0-x-wrapper--stuck .vtex-store-components-3-x-searchBarContainer.search-active {
-        padding: 12px;
+        max-height: 55px !important;
+        padding: 10px 15px !important;
     }
 }
 
 /* Ajustes para tablets */
 @media (min-width: 769px) and (max-width: 1024px) {
     .vtex-sticky-layout-0-x-wrapper--stuck .vtex-store-components-3-x-searchBarContainer.search-active {
-        padding: 18px;
+        max-height: 65px !important;
+        padding: 18px 15px !important;
     }
 }

--- a/react/SearchButton/index.global.css
+++ b/react/SearchButton/index.global.css
@@ -1,0 +1,166 @@
+/* Botão de busca */
+.search-button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    transition: all 0.2s ease;
+    border-radius: 4px;
+    min-width: 36px;
+    min-height: 36px;
+}
+
+/* Estilos para o search-bar original quando ativo no sticky */
+.vtex-sticky-layout-0-x-wrapper--stuck .vtex-store-components-3-x-searchBarContainer.search-active {
+    display: block !important;
+    visibility: visible !important;
+    height: auto !important;
+    max-height: none !important;
+    overflow: visible !important;
+    opacity: 1 !important;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    background: #d2d3d3;
+    border-top: 1px solid #e0e0e0;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    animation: slideDown 0.2s ease-out;
+    padding: 15px;
+    transform: translateY(0) !important;
+    pointer-events: auto !important;
+}
+
+/* Garante que quando não estiver sticky, o search-bar volte ao comportamento normal */
+.vtex-store-components-3-x-searchBarContainer:not(.search-active) {
+    display: block;
+    visibility: visible;
+    height: auto;
+    overflow: visible;
+    opacity: 1;
+    position: static !important;
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    animation: none !important;
+}
+
+@keyframes slideDown {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* Ajustes no input do search-bar original quando no modo sticky */
+.vtex-sticky-layout-0-x-wrapper--stuck .vtex-store-components-3-x-searchBarContainer.search-active .vtex-input-prefix__group {
+    width: 100% !important;
+    margin: 0 !important;
+    max-height: none !important;
+}
+
+.vtex-sticky-layout-0-x-wrapper--stuck .vtex-store-components-3-x-searchBarContainer.search-active input {
+    border-radius: 4px !important;
+    padding: 12px 16px !important;
+    font-size: 16px !important;
+    border: 0;
+}
+
+.vtex-sticky-layout-0-x-wrapper--stuck .vtex-store-components-3-x-searchBarContainer.search-active input:focus {
+    border-color: #ff6c00 !important;
+    box-shadow: 0 0 0 2px rgba(255, 108, 0, 0.1) !important;
+}
+
+/* Transições suaves para elementos que serão escondidos/mostrados */
+.vtex-store-components-3-x-searchBarContainer {
+    transition: opacity 0.3s ease, max-height 0.3s ease, padding 0.3s ease;
+    overflow: hidden;
+    display: block;
+}
+
+.vtex-flex-layout-0-x-flexRowContent--container-app-content,
+.vtex-flex-layout-0-x-flexRow--AppBanner,
+[class*="wrapperBannerApp"],
+.vtex-flex-layout-0-x-flexRowContent--AppBanner {
+    transition: opacity 0.3s ease, max-height 0.3s ease, transform 0.3s ease;
+    overflow: hidden;
+}
+
+/* Transição suave para o próprio sticky layout */
+.vtex-sticky-layout-0-x-wrapper {
+    transition: all 0.3s ease;
+}
+
+/* Transição suave para o container do sticky */
+.vtex-sticky-layout-0-x-container--sticky-header {
+    transition: all 0.3s ease;
+}
+
+/* Esconde o search bar original quando sticky no mobile */
+@media (max-width: 1024px) {
+    .vtex-sticky-layout-0-x-wrapper--stuck .vtex-store-components-3-x-searchBarContainer:not(.search-active) {
+        opacity: 0;
+        max-height: 0;
+        padding-top: 0;
+        padding-bottom: 0;
+        transform: translateY(-10px);
+        pointer-events: none;
+    }
+
+    /* Esconde o AppBanner quando o header estiver sticky - várias tentativas de seletor */
+    .vtex-sticky-layout-0-x-wrapper--stuck .vtex-flex-layout-0-x-flexRowContent--container-app-content {
+        opacity: 0;
+        max-height: 0;
+        transform: translateY(-10px);
+    }
+
+    .vtex-sticky-layout-0-x-wrapper--stuck .vtex-flex-layout-0-x-flexRow--AppBanner {
+        opacity: 0;
+        max-height: 0;
+        transform: translateY(-10px);
+    }
+
+    /* Tenta pelo componente direto */
+    .vtex-sticky-layout-0-x-wrapper--stuck [class*="wrapperBannerApp"] {
+        opacity: 0;
+        max-height: 0;
+        transform: translateY(-10px);
+    }
+
+    /* Tenta pelo flex-layout que contém o AppBanner */
+    .vtex-sticky-layout-0-x-wrapper--stuck .vtex-flex-layout-0-x-flexRowContent--AppBanner {
+        opacity: 0;
+        max-height: 0;
+        transform: translateY(-10px);
+    }
+}
+
+/* Ajustes responsivos */
+@media (max-width: 768px) {
+    .search-button {
+        padding: 0px;
+        min-width: 28px;
+        min-height: 32px;
+    }
+
+    .vtex-sticky-layout-0-x-wrapper--stuck .vtex-store-components-3-x-searchBarContainer.search-active {
+        padding: 12px;
+    }
+}
+
+/* Ajustes para tablets */
+@media (min-width: 769px) and (max-width: 1024px) {
+    .vtex-sticky-layout-0-x-wrapper--stuck .vtex-store-components-3-x-searchBarContainer.search-active {
+        padding: 18px;
+    }
+}

--- a/react/SearchButton/index.global.css
+++ b/react/SearchButton/index.global.css
@@ -1,6 +1,5 @@
 /* Wrapper do botão de busca com controle de max-width */
 .search-button-wrapper {
-    max-width: 0;
     opacity: 0;
     overflow: hidden;
     transition: all 0.3s ease;
@@ -24,7 +23,6 @@
 
 /* Para garantir que o botão só apareça quando sticky E quando a search externa não estiver visível */
 .search-button-wrapper:not(.search-button-wrapper--sticky) {
-    max-width: 0;
     pointer-events: none;
 }
 

--- a/react/SearchButton/index.global.css
+++ b/react/SearchButton/index.global.css
@@ -1,8 +1,7 @@
 /* Wrapper do botão de busca com controle de max-width */
 .search-button-wrapper {
-    opacity: 0;
     overflow: hidden;
-    transition: all 0.3s ease;
+    transition: all 0.35s ease-in-out;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -12,7 +11,7 @@
 .search-button-wrapper--sticky {
     max-width: 45px;
     pointer-events: auto;
-    opacity: 1;
+    opacity: 1!important;
 }
 
 /* Quando estiver sticky E ativo (search visível), mantém os 45px */

--- a/react/SearchButton/index.jsx
+++ b/react/SearchButton/index.jsx
@@ -5,6 +5,7 @@ import './index.global.css'
 const SearchButton = () => {
   const [isSearchVisible, setIsSearchVisible] = useState(false)
   const [isSticky, setIsSticky] = useState(false)
+  const [isExternalSearchVisible, setIsExternalSearchVisible] = useState(true)
   const searchButtonRef = useRef(null)
 
   useEffect(() => {
@@ -30,6 +31,24 @@ const SearchButton = () => {
             searchBarContainer.style.display = ''
           }
         }
+      }
+    }
+
+    const checkExternalSearchVisibility = () => {
+      // A lógica é simples: 
+      // - Se o sticky está "stuck", a search-bar externa está atrás do header (invisível)
+      // - Se não está "stuck", a search-bar externa está visível
+      const stickyWrapper = document.querySelector('.vtex-sticky-layout-0-x-wrapper')
+      
+      if (stickyWrapper) {
+        const isStuck = stickyWrapper.classList.contains('vtex-sticky-layout-0-x-wrapper--stuck')
+        
+        // Quando stuck = search externa invisível (atrás do header)
+        // Quando não stuck = search externa visível
+        setIsExternalSearchVisible(!isStuck)
+      } else {
+        // Desktop ou caso não encontre o sticky - assume visível
+        setIsExternalSearchVisible(true)
       }
     }
 
@@ -84,33 +103,55 @@ const SearchButton = () => {
 
     // Verifica estado inicial
     checkStickyState()
+    checkExternalSearchVisibility()
+
+    // Observer para mudanças no DOM que podem afetar a visibilidade da search-bar externa
+    const externalSearchObserver = new MutationObserver(() => {
+      checkExternalSearchVisibility()
+    })
+
+    // Observa mudanças no body para capturar alterações na search-bar externa
+    externalSearchObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['class', 'style']
+    })
+
+    // Verifica periodicamente a visibilidade da search-bar externa
+    const intervalId = setInterval(checkExternalSearchVisibility, 1000)
 
     // Cleanup
     return () => {
       observer.disconnect()
+      externalSearchObserver.disconnect()
+      clearInterval(intervalId)
       document.removeEventListener('click', handleDocumentInteraction)
       document.removeEventListener('keydown', handleDocumentInteraction)
     }
   }, [isSticky, isSearchVisible])
 
   const showSearchBar = () => {
-    const searchBarContainer = document.querySelector('.vtex-store-components-3-x-searchBarContainer')
-    if (searchBarContainer) {
-      // Apenas adiciona a classe para mostrar, sem manipular style.display
-      searchBarContainer.classList.add('search-active')
-      
-      // Foca no input do search-bar original
-      const searchInput = searchBarContainer.querySelector('input')
-      if (searchInput) {
-        setTimeout(() => {
-          searchInput.focus()
-        }, 100)
+    // Só mostra a search-bar no sticky se a search-bar externa estiver atrás do header
+    if (!isExternalSearchVisible && isSticky) {
+      const searchBarContainer = document.querySelector('.vtex-sticky-layout-0-x-wrapper--stuck .vtex-store-components-3-x-searchBarContainer')
+      if (searchBarContainer) {
+        // Adiciona a classe para mostrar no sticky
+        searchBarContainer.classList.add('search-active')
+        
+        // Foca no input do search-bar
+        const searchInput = searchBarContainer.querySelector('input')
+        if (searchInput) {
+          setTimeout(() => {
+            searchInput.focus()
+          }, 100)
+        }
       }
     }
   }
 
   const hideSearchBar = () => {
-    const searchBarContainer = document.querySelector('.vtex-store-components-3-x-searchBarContainer')
+    const searchBarContainer = document.querySelector('.vtex-sticky-layout-0-x-wrapper--stuck .vtex-store-components-3-x-searchBarContainer')
     if (searchBarContainer) {
       // Remove a classe e limpa qualquer style.display que possa ter sido aplicado
       searchBarContainer.classList.remove('search-active')
@@ -119,34 +160,34 @@ const SearchButton = () => {
   }
 
   const handleSearchToggle = () => {
-    if (isSearchVisible) {
-      setIsSearchVisible(false)
-      hideSearchBar()
-    } else {
-      setIsSearchVisible(true)
-      showSearchBar()
+    // Só permite toggle se estivermos no sticky e a search-bar externa estiver atrás do header
+    if (isSticky && !isExternalSearchVisible) {
+      if (isSearchVisible) {
+        setIsSearchVisible(false)
+        hideSearchBar()
+      } else {
+        setIsSearchVisible(true)
+        showSearchBar()
+      }
     }
   }
 
-  // Só renderiza o botão no mobile quando estiver sticky
-  if (!isSticky) {
-    return null
-  }
-
   return (
-    <button
-      ref={searchButtonRef}
-      className={`search-button ${isSearchVisible ? 'search-button--active' : ''}`}
-      onClick={handleSearchToggle}
-      aria-label={isSearchVisible ? 'Fechar busca' : 'Abrir busca'}
-      tabIndex="0"
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          handleSearchToggle()
-        }
-      }}
-    >
+    <div className={`search-button-wrapper ${isSticky && !isExternalSearchVisible ? 'search-button-wrapper--sticky' : ''} ${isSearchVisible ? 'search-button-wrapper--active' : ''}`}>
+      <button
+        ref={searchButtonRef}
+        className={`search-button ${isSearchVisible ? 'search-button--active' : ''}`}
+        onClick={handleSearchToggle}
+        aria-label={isSearchVisible ? 'Fechar busca' : 'Abrir busca'}
+        tabIndex="0"
+        disabled={!isSticky || isExternalSearchVisible}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            handleSearchToggle()
+          }
+        }}
+      >
       <svg width="28" height="28" viewBox="0 0 28 29" fill="none" xmlns="http://www.w3.org/2000/svg">
         <g clipPath="url(#clip0_42827_5106)">
             <path d="M12.8109 23.0957C17.9532 23.0957 22.1218 18.9271 22.1218 13.7848C22.1218 8.64251 17.9532 4.47388 12.8109 4.47388C7.66864 4.47388 3.5 8.64251 3.5 13.7848C3.5 18.9271 7.66864 23.0957 12.8109 23.0957Z" stroke="white" stroke-width="1.59616" stroke-linecap="round" stroke-linejoin="round"/>
@@ -159,7 +200,8 @@ const SearchButton = () => {
         </defs>
     </svg>
 
-    </button>
+      </button>
+    </div>
   )
 }
 

--- a/react/SearchButton/index.jsx
+++ b/react/SearchButton/index.jsx
@@ -1,0 +1,166 @@
+import React, { useState, useEffect, useRef } from 'react'
+import { IconSearch } from 'vtex.store-icons'
+import './index.global.css'
+
+const SearchButton = () => {
+  const [isSearchVisible, setIsSearchVisible] = useState(false)
+  const [isSticky, setIsSticky] = useState(false)
+  const searchButtonRef = useRef(null)
+
+  useEffect(() => {
+    const checkStickyState = () => {
+      // Verifica se existe um elemento com a classe stuck
+      const stickyElement = document.querySelector('.vtex-sticky-layout-0-x-wrapper--stuck')
+      const newStickyState = !!stickyElement
+      
+      if (newStickyState !== isSticky) {
+        setIsSticky(newStickyState)
+        
+        // Se não estiver mais sticky, esconde o search e limpa qualquer estado
+        if (!newStickyState && isSearchVisible) {
+          setIsSearchVisible(false)
+          hideSearchBar()
+        }
+        
+        // Se não estiver sticky, garante que o search-bar não tenha modificações de estilo
+        if (!newStickyState) {
+          const searchBarContainer = document.querySelector('.vtex-store-components-3-x-searchBarContainer')
+          if (searchBarContainer) {
+            searchBarContainer.classList.remove('search-active')
+            searchBarContainer.style.display = ''
+          }
+        }
+      }
+    }
+
+    // Handler para fechar com ESC ou clique fora
+    const handleDocumentInteraction = (e) => {
+      if (!isSearchVisible) return
+
+      // Fecha com ESC
+      if (e.type === 'keydown' && e.key === 'Escape') {
+        setIsSearchVisible(false)
+        hideSearchBar()
+        return
+      }
+
+      // Fecha clicando fora
+      if (e.type === 'click') {
+        const searchBar = document.querySelector('.vtex-store-components-3-x-searchBarContainer.search-active')
+        const searchButton = searchButtonRef.current
+        
+        if (searchBar && searchButton && 
+            !searchBar.contains(e.target) && 
+            !searchButton.contains(e.target)) {
+          setIsSearchVisible(false)
+          hideSearchBar()
+        }
+      }
+    }
+
+    // Observador para mudanças na classe sticky
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+          checkStickyState()
+        }
+      })
+    })
+
+    // Observa o elemento sticky layout
+    const stickyLayout = document.querySelector('.vtex-sticky-layout-0-x-wrapper')
+    if (stickyLayout) {
+      observer.observe(stickyLayout, {
+        attributes: true,
+        attributeFilter: ['class']
+      })
+    }
+
+    // Adiciona listeners para fechar o search
+    if (isSearchVisible) {
+      document.addEventListener('click', handleDocumentInteraction)
+      document.addEventListener('keydown', handleDocumentInteraction)
+    }
+
+    // Verifica estado inicial
+    checkStickyState()
+
+    // Cleanup
+    return () => {
+      observer.disconnect()
+      document.removeEventListener('click', handleDocumentInteraction)
+      document.removeEventListener('keydown', handleDocumentInteraction)
+    }
+  }, [isSticky, isSearchVisible])
+
+  const showSearchBar = () => {
+    const searchBarContainer = document.querySelector('.vtex-store-components-3-x-searchBarContainer')
+    if (searchBarContainer) {
+      // Apenas adiciona a classe para mostrar, sem manipular style.display
+      searchBarContainer.classList.add('search-active')
+      
+      // Foca no input do search-bar original
+      const searchInput = searchBarContainer.querySelector('input')
+      if (searchInput) {
+        setTimeout(() => {
+          searchInput.focus()
+        }, 100)
+      }
+    }
+  }
+
+  const hideSearchBar = () => {
+    const searchBarContainer = document.querySelector('.vtex-store-components-3-x-searchBarContainer')
+    if (searchBarContainer) {
+      // Remove a classe e limpa qualquer style.display que possa ter sido aplicado
+      searchBarContainer.classList.remove('search-active')
+      searchBarContainer.style.display = ''
+    }
+  }
+
+  const handleSearchToggle = () => {
+    if (isSearchVisible) {
+      setIsSearchVisible(false)
+      hideSearchBar()
+    } else {
+      setIsSearchVisible(true)
+      showSearchBar()
+    }
+  }
+
+  // Só renderiza o botão no mobile quando estiver sticky
+  if (!isSticky) {
+    return null
+  }
+
+  return (
+    <button
+      ref={searchButtonRef}
+      className={`search-button ${isSearchVisible ? 'search-button--active' : ''}`}
+      onClick={handleSearchToggle}
+      aria-label={isSearchVisible ? 'Fechar busca' : 'Abrir busca'}
+      tabIndex="0"
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          handleSearchToggle()
+        }
+      }}
+    >
+      <svg width="28" height="28" viewBox="0 0 28 29" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <g clipPath="url(#clip0_42827_5106)">
+            <path d="M12.8109 23.0957C17.9532 23.0957 22.1218 18.9271 22.1218 13.7848C22.1218 8.64251 17.9532 4.47388 12.8109 4.47388C7.66864 4.47388 3.5 8.64251 3.5 13.7848C3.5 18.9271 7.66864 23.0957 12.8109 23.0957Z" stroke="white" stroke-width="1.59616" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M20.3948 20.668L26.8461 27.1193" stroke="white" strokeWidth="1.59616" strokeLinecap="round" strokeLinejoin="round"/>
+        </g>
+        <defs>
+            <clipPath id="clip0_42827_5106">
+                <rect width="28" height="28" fill="white" transform="translate(0 0.888916)"/>
+            </clipPath>
+        </defs>
+    </svg>
+
+    </button>
+  )
+}
+
+export default SearchButton

--- a/store/blocks/header/header.jsonc
+++ b/store/blocks/header/header.jsonc
@@ -157,6 +157,7 @@
   "flex-layout.row#1-mobile": {
     "children": [
       "flex-layout.row#header-mobile-left",
+      "logo#mobile",
       "flex-layout.row#header-mobile-right"
     ],
     "props": {
@@ -167,7 +168,7 @@
     }
   },
   "flex-layout.row#header-mobile-left": {
-    "children": ["drawer", "logo#mobile"],
+    "children": ["drawer"],
     "props": {
       "blockClass": ["header-mobile-left"],
       "preventHorizontalStretch": true,
@@ -175,7 +176,7 @@
     }
   },
   "flex-layout.row#header-mobile-right": {
-    "children": ["login", "minicart.v2"],
+    "children": ["search-button","login", "minicart.v2"],
     "props": {
       "blockClass": ["header-mobile-right"],
       "preventHorizontalStretch": true,

--- a/store/blocks/header/header.jsonc
+++ b/store/blocks/header/header.jsonc
@@ -99,20 +99,13 @@
   "header-layout.mobile": {
     "children": [
       "flex-layout.row#hintup-skeleton",
-      "sticky-layout#1-envie-sua-receita-mobile",
+      "flex-layout.row#1-envie-sua-receita-mobile",
+      "flex-layout.row#AppBanner",
       "sticky-layout#1-mobile",
+      "search-bar",
       "CryptoScript",
       "CartOpenerScript"
     ]
-  },
-  "sticky-layout#1AppBanner": {
-    "props": {
-      "blockClass": "bloco-AppBanner",
-      "preventHorizontalStretch": true,
-      "preserveLayoutOnMobile": true,
-      "fullWidth": true
-    },
-    "children": ["flex-layout.row#AppBanner"]
   },
   "flex-layout.row#AppBanner": {
     "props": {
@@ -121,12 +114,12 @@
     },
     "children": ["AppBanner"]
   },
-  "sticky-layout#1-envie-sua-receita-mobile": {
-    "props": {
-      "blockClass": "bloco-envie-sua-receita-mobile-topo"
-    },
-    "children": ["flex-layout.row#1-envie-sua-receita-mobile"]
-  },
+  // "sticky-layout#1-envie-sua-receita-mobile": {
+  //   "props": {
+  //     "blockClass": "bloco-envie-sua-receita-mobile-topo"
+  //   },
+  //   "children": ["flex-layout.row#1-envie-sua-receita-mobile"]
+  // },
   "flex-layout.row#1-envie-sua-receita-mobile": {
     "children": ["rich-text#envie-sua-receita-mobile"],
     "props": {
@@ -151,7 +144,6 @@
       "blockClass": "sticky-header"
     },
     "children": [
-      "flex-layout.row#AppBanner",
       "flex-layout.row#1-mobile",
       "search-bar"
     ]

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -61,5 +61,8 @@
   },
   "FaqComponent": {
     "component": "FaqComponent"
+  },
+  "search-button": {
+    "component": "SearchButton"
   }
 }

--- a/styles/css/stevia.slider-layout-seo.css
+++ b/styles/css/stevia.slider-layout-seo.css
@@ -128,7 +128,7 @@
     }
 
     .sliderLayoutContainer--carousel {
-        margin-top: 0 !important;
+        margin-top: 85px !important;
     }
 }
 

--- a/styles/css/stevia.slider-layout-seo.css
+++ b/styles/css/stevia.slider-layout-seo.css
@@ -127,9 +127,9 @@
         font-family: Signika;
     }
 
-    .sliderLayoutContainer--carousel {
+    /* .sliderLayoutContainer--carousel {
         margin-top: 85px !important;
-    }
+    } */
 }
 
 .sliderLayoutContainer--shelf :global(.vtex-product-price-1-x-sellingPrice),

--- a/styles/css/vtex.flex-layout.css
+++ b/styles/css/vtex.flex-layout.css
@@ -151,9 +151,6 @@
     display: flex;
     gap: 20px;
   }
-  .flexRowContent--header-mobile-right {
-    gap: 30px;
-  }
   .flexCol--mobile-menu-message {
     margin-top: 28px;
   }

--- a/styles/css/vtex.login.css
+++ b/styles/css/vtex.login.css
@@ -70,10 +70,10 @@
   .container :global(.vtex-button) :global(.vtex-button__label) .label,
   .profile {
     display: block;
-    padding-top: 33px;
-    font-size: 10px !important;
-    background-size: 27px;
-    width: 32px;
+    padding-top: 25px;
+    font-size: 0px !important;
+    background-size: 25px;
+    width: 25px;
     background-image: url(/arquivos/new-profile-mobile.svg) !important;
     font-family: "Signika";
   }

--- a/styles/css/vtex.store-components.css
+++ b/styles/css/vtex.store-components.css
@@ -379,7 +379,6 @@
 :global(.vtex-flex-layout-0-x-flexRowContent--main-header-mobile) {
   color: #fff;
   background-color: #009fc2;
-  border-bottom: 3px solid #ff6c00;
 }
 .bg-emphasis {
   background-color: #ff6c00 !important;
@@ -1786,9 +1785,7 @@
   }
   :global(.vtex-sticky-layout-0-x-wrapper) {
     background-color: #009fc2;
-    border-bottom: 3px solid #ff6c00;
-    height: auto!important;
-    max-height: 100px!important;
+    /* height: auto!important; */
   }
   :global(.vtex-sticky-layout-0-x-container) {
     background-color: #009fc2;
@@ -2216,6 +2213,10 @@
     max-width: 100vw;
     padding: 10px 10px;
     border-bottom: 2px solid #ff6c00;
+    background-color: #d2d3d3;
+  }
+  :global(.vtex-sticky-layout-0-x-wrapper) .searchBarContainer {
+    padding: 0;
   }
   .searchBarInnerContainer {
     width: unset !important;
@@ -2562,4 +2563,11 @@
     max-height: 300px;
     transition: all 0.3s ease-in-out;
   }
+}
+
+/* Estado inicial da search-bar dentro do sticky - invisível */
+:global(.vtex-sticky-layout-0-x-wrapper) :global(.vtex-store-components-3-x-searchBarContainer) {
+  opacity: 0 !important;
+  max-height: 0 !important;
+  overflow: hidden !important;
 }

--- a/styles/css/vtex.store-components.css
+++ b/styles/css/vtex.store-components.css
@@ -1787,10 +1787,11 @@
   :global(.vtex-sticky-layout-0-x-wrapper) {
     background-color: #009fc2;
     border-bottom: 3px solid #ff6c00;
+    height: auto!important;
+    max-height: 100px!important;
   }
   :global(.vtex-sticky-layout-0-x-container) {
     background-color: #009fc2;
-    border-bottom: 3px solid #ff6c00;
   }
   :global(.vtex-store-components-3-x-searchBarInnerContainer) {
     margin-top: 0;
@@ -1850,11 +1851,11 @@
     padding-bottom: 5px;
   }
   :global(.vtex-minicart-2-x-minicartContainer) {
-    margin-top: 3px;
-    background-position: 12px 9px;
+    margin-top: 0px;
+    background-position: 0;
     background-image: url(/arquivos/new-minicart-icon.svg) !important;
     width: fit-content !important;
-    background-size: 60%;
+    background-size: 22px;
   }
   :global(.vtex-minicart-2-x-openIconContainer),
   :global(.vtex-minicart-2-x-minicartWrapperContainer) {
@@ -2207,10 +2208,14 @@
 .imageElement--carousel {
   max-height: initial !important;
 }
+:global(.vtex-search-2-x-biggy-autocomplete) {
+  display: none;
+}
 @media (max-width: 1024px) {
   .searchBarContainer {
     max-width: 100vw;
     padding: 10px 10px;
+    border-bottom: 2px solid #ff6c00;
   }
   .searchBarInnerContainer {
     width: unset !important;
@@ -2234,15 +2239,14 @@
     max-width: initial;
     max-height: initial;
     min-width: initial;
-    width: 119px;
-    height: 48px;
+    width: auto;
+    height: 55px;
     padding: 0;
   }
   .logoContainer .logoImage {
-    width: 169px;
-    height: 68px;
+    height: 55px;
+    width: auto;
     margin: 0;
-    margin-left: 12px;
   }
 }
 :global(.vtex-store-components-3-x-subscribeLabel),
@@ -2549,5 +2553,13 @@
     width: 20px;
     height: 23px;
     background: url(/arquivos/mobile-drawer-8.svg) center/100% no-repeat;
+  }
+}
+
+
+@media(min-width: 980px){
+  :global(.vtex-sticky-layout-0-x-wrapper){
+    max-height: 300px;
+    transition: all 0.3s ease-in-out;
   }
 }


### PR DESCRIPTION
# Título do PR: task12356: feat: adicionar barra de busca ativa com botão no mobile quando o header for sticky

## 🎯 Tipo de Mudança
> Marque o tipo de mudança que este PR introduz

- [ ] 🐛 **Correção de bug** (alteração que corrige um problema)
- [X] ✨ **Novo recurso** (alteração que adiciona uma funcionalidade)
- [ ] ♻️ **Refatoração** (uma alteração de código que não corrige um bug nem adiciona um recurso)
- [ ] 📖 **Documentação** (atualizações na documentação)

---

## 📝 Descrição
> Descreva suas mudanças em detalhes. Qual o problema que está sendo resolvido? Qual a solução implementada? _Se aplicável, adicione o contexto que motivou esta mudança._

1. Queremos ajustar alguns itens visuais para deixar a tela mais limpa no mobile (sem tanta “poluição”). Seguem as alterações (a exclusão dos botões de ofertas e do Omni, serve para o desktop também):


Otimizar a barra de busca, para ficar menor quando a pessoa desce a página (ficando ao lado do login e do logo da Biostévi). A ideia é ela aparecer aberta para o usuário, como está atualmente, mas quando ele começar a descer a página, essa barra de pesquisa sumiria e a lupa iria se “integrar” com o layout de cima. Exemplo de como a barra de pesquisa funcionária: [Vídeo no drive](https://drive.google.com/drive/folders/1A7Us9jWdGr70zkJ2jtwq3zbwPRZsHGZD)

---

## 📸 Evidências Visuais (Se aplicável)
> Adicione capturas de tela, GIFs ou vídeos para demonstrar as mudanças de UI/UX.

**Antes:**
Não sticky:
<img width="403" height="297" alt="image" src="https://github.com/user-attachments/assets/1f59e8fd-cc35-44f3-884b-d4232f4e8570" />
Sticky:
<img width="405" height="499" alt="image" src="https://github.com/user-attachments/assets/b92deaec-ab01-4a35-9a8e-c8e48169811e" />

**Depois:**
Não sticky:
<img width="403" height="297" alt="image" src="https://github.com/user-attachments/assets/1f59e8fd-cc35-44f3-884b-d4232f4e8570" />
Sticky:
<img width="406" height="141" alt="image" src="https://github.com/user-attachments/assets/1a368f18-0ba2-4c73-b7a9-f25f70a475f7" />

---

## ✅ Checklist de Qualidade

- [X] Meu código segue as diretrizes deste projeto.
- [X] Realizei uma revisão do meu próprio código.
- [X] Testei o fluxo de navegação.
- [X] Comentei meu código nas áreas de difícil compreensão.
- [X] Minhas alterações não geram novos warnings.

---

## 🔗 Referências
> Adicione links para tarefas, épicos ou outras referências.

- **Tarefa:** [TASK-12356](https://runrun.it/pt-BR/tasks/12356)
- **Design no Figma:** [Link para o design](https://www.figma.com/design/MqQ0501nfKJpmdcN71QHLt/-12356_Item-01---Otimizar-a-barra-de-busca?node-id=40861-2851&t=D6oOCK8bDpWBiXKX-1)
- **Referência em vídeo:** [Vídeo no drive](https://drive.google.com/drive/folders/1A7Us9jWdGr70zkJ2jtwq3zbwPRZsHGZD)