### PR TITLE
hotfix/task-13552

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "stevia",
   "name": "minimumtheme",
-  "version": "8.0.28",
+  "version": "8.0.29",
   "builders": {
     "styles": "2.x",
     "store": "0.x",

--- a/store/blocks/search-landing.jsonc
+++ b/store/blocks/search-landing.jsonc
@@ -71,7 +71,6 @@
       "breadcrumb.search",
       // "search-title.v2",
       "CategoryHeading",
-      "flex-layout.row#top",
       "search-fetch-previous",
       "flex-layout.row#results",
       "search-fetch-more"
@@ -81,17 +80,23 @@
       "preventRouteChange": true
     }
   },
-  "flex-layout.row#top": {
+  "flex-layout.row#top-infos": {
     "children": [
       "total-products.v2",
       "order-by.v2"
-    ]
+    ],
+    "props": {
+      "colSizing": "auto"
+    }
   },
   "flex-layout.row#results": {
     "children": [
       "flex-layout.col#filter",
       "flex-layout.col#search"
-    ]
+    ],
+    "props": {
+      "colSizing": "auto"
+    }
   },
   "flex-layout.col#filter": {
     "props": {
@@ -103,8 +108,12 @@
   },
   "flex-layout.col#search": {
     "children": [
+      "flex-layout.row#top-infos",
       "search-content"
-    ]
+    ],
+    "props": {
+      "colSizing": "auto"
+    }
   },
   "search-content": {
     "blocks": [

--- a/styles/css/vtex.breadcrumb.css
+++ b/styles/css/vtex.breadcrumb.css
@@ -1,0 +1,3 @@
+.link {
+    font-family: Signika;
+}


### PR DESCRIPTION
# Título do PR: task13552: hotfix: Corrige quebra do filtro na página de Influencers

## 🎯 Tipo de Mudança
> Marque o tipo de mudança que este PR introduz

- [x] 🐛 **Correção de bug** (alteração que corrige um problema)
- [ ] ✨ **Novo recurso** (alteração que adiciona uma funcionalidade)
- [ ] ♻️ **Refatoração** (uma alteração de código que não corrige um bug nem adiciona um recurso)
- [ ] 📖 **Documentação** (atualizações na documentação)
- [ ] 🎨 **Alteração de layout** (Mudança no layout sem alterar o comportamento de uma funcionalidade existente)
---

## 📝 Descrição
> Descreva suas mudanças em detalhes. Qual o problema que está sendo resolvido? Qual a solução implementada? _Se aplicável, adicione o contexto que motivou esta mudança._

Um bloco estava com nome duplicado, o mesmo nome para blocos diferentes. A página de influencers começou a trazer o título de Lista de Desejos como h3, e perdemos a quantidade de produtos e ordenação, além de uma quebra visual dos filtros e produtos.

Corrigimos a duplicidade alterando o nome de um dos componentes, e garantindo que o filtro e os produtos permaneçam da forma correta.

---

## 📸 Evidências Visuais (Se aplicável)
> Adicione capturas de tela, GIFs ou vídeos para demonstrar as mudanças de UI/UX.

**Antes:**
<img width="1045" height="442" alt="image" src="https://github.com/user-attachments/assets/7e084283-3520-4ac6-8b05-a5cf68054916" />


**Depois:**
<img width="1366" height="720" alt="image" src="https://github.com/user-attachments/assets/41f6233c-296e-4b02-8517-310a8d45d1cb" />


---

## ✅ Checklist de Qualidade

- [x] Meu código segue as diretrizes deste projeto.
- [x] Realizei uma revisão do meu próprio código.
- [x] Testei o fluxo de navegação.
- [x] Comentei meu código nas áreas de difícil compreensão.
- [x] Minhas alterações não geram novos warnings.

---

## 🔗 Referências
> Adicione links para tarefas, épicos ou outras referências.

- **Tarefa:** [TASK-13552](https://runrun.it/pt-BR/tasks/13552)